### PR TITLE
cvt-macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
     "early-panic",
     "nondet", 
     "solana_cvt",
+    "cvt-macros",
     "stubs"
 ]

--- a/cvt-macros/Cargo.toml
+++ b/cvt-macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cvt-macros"
+version = "0.0.1"
+authors = ["Arie Gurfinkel <arie@certora.com>"]
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { version = "1", features = ["nightly"] }
+quote = "1"
+syn = {version = "2.0.48", features = ["visit-mut", "full"] }

--- a/cvt-macros/src/lib.rs
+++ b/cvt-macros/src/lib.rs
@@ -1,0 +1,24 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, ItemFn};
+
+
+/// Mark a method as a CVT rule
+///
+/// # Example
+///
+/// ```
+/// use cvt_macros::rule;
+/// use cvt::CVT_assert;
+/// #[rule]
+/// fn foo()  {
+///    cvt::CVT_assert(false);
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn rule(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut fn_ast = parse_macro_input!(input as ItemFn);
+    // add #[no_mangle] attribute
+    fn_ast.attrs.push(parse_quote!(#[no_mangle]));
+    TokenStream::from(quote!(#fn_ast))
+}


### PR DESCRIPTION
A new module to host any and all macros that we want to create before they can be moved into their own crate.

For now, there is one macro `#[rule]` that is used to mark specification rules